### PR TITLE
Fix extra comma if there are no toolbar children

### DIFF
--- a/webappbuilder/themes/basic/app.js
+++ b/webappbuilder/themes/basic/app.js
@@ -61,10 +61,9 @@ var BasicApp = React.createClass({
     ToolActions.activateTool(null, 'navigation');
   },
   render() {
-    var toolbarElements = [@TOOLBAR@];
     var toolbarOptions = @TOOLBAROPTIONS@;
     return React.createElement("div", {id: 'content'},
-      React.createElement(AppBar, toolbarOptions,
+      React.createElement(AppBar, toolbarOptions
        @TOOLBAR@
       ),
       React.createElement("div", {id: 'map', ref: 'map'}

--- a/webappbuilder/themes/basic/app.jsx
+++ b/webappbuilder/themes/basic/app.jsx
@@ -80,7 +80,7 @@ class BasicApp extends App {
   render() {
     var toolbarOptions = @TOOLBAROPTIONS@;
     return React.createElement("article", null,
-       React.createElement(AppBar, toolbarOptions,
+       React.createElement(AppBar, toolbarOptions
        @TOOLBAR@
        ),
       React.createElement("div", {id: 'content'},

--- a/webappbuilder/themes/tabbed/app.js
+++ b/webappbuilder/themes/tabbed/app.js
@@ -72,10 +72,9 @@ var TabbedApp = React.createClass({
     }
   },
   render() {
-    var toolbarElements = [@TOOLBAR@];
     var toolbarOptions = @TOOLBAROPTIONS@;
     return React.createElement("div", {id: 'content'},
-      React.createElement(AppBar, toolbarOptions,
+      React.createElement(AppBar, toolbarOptions
         @TOOLBAR@
       ),
       React.createElement("div", {className: 'row container'},

--- a/webappbuilder/themes/tabbed/app.jsx
+++ b/webappbuilder/themes/tabbed/app.jsx
@@ -79,7 +79,7 @@ class TabbedApp extends App {
   render() {
     var toolbarOptions = @TOOLBAROPTIONS@;
     return React.createElement("div", {id: 'content'},
-      React.createElement(AppBar, toolbarOptions,
+      React.createElement(AppBar, toolbarOptions
         @TOOLBAR@
       ),
       React.createElement("div", {className: 'row container'},


### PR DESCRIPTION
When the toolbar has no children, an extra comma would get generated, which would make the application fail.