### PR TITLE
Fix definition of hideAboutPanel in basic/app.jsx

### DIFF
--- a/webappbuilder/themes/basic/app.jsx
+++ b/webappbuilder/themes/basic/app.jsx
@@ -76,7 +76,7 @@ class BasicApp extends React.Component {
   _toggleEdit() {
     this._toggle(document.getElementById('edit-tool-panel'));
   }
-  _hideAboutPanel: function(evt) {
+  _hideAboutPanel(evt) {
     evt.preventDefault();
     document.getElementById('about-panel').style.display = 'none';
   }


### PR DESCRIPTION
To fix

```
> webapp@0.0.0 build:js /home/bartvde/tmp/wab/webapp
> browserify app.jsx | uglifyjs --output build/app.js

SyntaxError: /home/bartvde/tmp/wab/webapp/app.jsx: Unexpected token (541:19)
    this._toggle(document.getElementById('edit-tool-panel'));
  }
  _hideAboutPanel: function(evt) {
    evt.preventDefault();
    document.getElementById('about-panel').style.display = 'none';
  }
    at Parser.pp.raise (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/parser/location.js:24:13)
    at Parser.pp.unexpected (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/parser/util.js:82:8)
    at Parser.pp.flowParsePrimaryType (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:552:8)
    at Parser.pp.flowParsePostfixType (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:557:38)
    at Parser.pp.flowParsePrefixType (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:573:17)
    at Parser.pp.flowParseIntersectionType (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:579:19)
    at Parser.pp.flowParseUnionType (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:589:19)
    at Parser.pp.flowParseType (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:600:19)
    at Parser.pp.flowParseTypeInitialiser (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:20:19)
    at Parser.pp.flowParseTypeAnnotation (/home/bartvde/tmp/wab/webapp/node_modules/babylon/lib/plugins/flow.js:607:30)
```