### PR TITLE
Fix overlap between about and bookmarks panel

### DIFF
--- a/webappbuilder/themes/basic/app.css
+++ b/webappbuilder/themes/basic/app.css
@@ -135,6 +135,10 @@ html, body {
   width: 100%;
   z-index: 101;
 }
+#bookmarks-panel {
+  position: absolute;
+  left: 25px;
+}
 .about-panel {
   display: block;
   position: absolute;
@@ -142,9 +146,9 @@ html, body {
   padding: 15px;
   border-radius: 5px;
   border: 1px solid #000000;
-  top: 100px;
-  left: 50px;
-  height: 500px;
+  top: 250px;
+  left: 75px;
+  height: 300px;
   width: 300px;
   min-width: 300px;
   z-index: 100;


### PR DESCRIPTION
closes #204 

![selection_205](https://cloud.githubusercontent.com/assets/319678/24556459/b45181d6-1634-11e7-8bde-7abda1ddf14d.png)
